### PR TITLE
Add ElevenLabs web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# elevenlabs-js
+# ElevenLabs JS Demo
+
+This project contains a simple web application that demonstrates how to use the [ElevenLabs](https://elevenlabs.io/) text-to-speech API.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18 or newer
+- An ElevenLabs API key
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create a `.env` file in the project root and add your API key:
+
+```
+ELEVENLABS_API_KEY=your_api_key_here
+```
+
+## Running the Application
+
+Start the development server with:
+
+```bash
+npm start
+```
+
+Open your browser at [http://localhost:3000](http://localhost:3000) to use the application. Enter text, choose a voice and model, and press **Speak** to hear the generated speech.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "elevenlabs-web",
+  "version": "1.0.0",
+  "description": "Simple web app using ElevenLabs API",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.1",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ElevenLabs TTS Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    textarea { width: 100%; height: 100px; }
+  </style>
+</head>
+<body>
+  <h1>ElevenLabs Text to Speech</h1>
+  <label for="text">Text:</label><br>
+  <textarea id="text" placeholder="Enter text here..."></textarea><br><br>
+
+  <label for="voice">Voice:</label>
+  <select id="voice"></select>
+
+  <label for="model">Model:</label>
+  <select id="model">
+    <option value="eleven_monolingual_v1">eleven_monolingual_v1</option>
+    <option value="eleven_multilingual_v1">eleven_multilingual_v1</option>
+  </select>
+  <br><br>
+  <button id="speak">Speak</button>
+  <audio id="audio" controls style="display:block;margin-top:1em;"></audio>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,34 @@
+async function fetchVoices() {
+  try {
+    const res = await fetch('/voices');
+    const data = await res.json();
+    const select = document.getElementById('voice');
+    data.voices.forEach(v => {
+      const option = document.createElement('option');
+      option.value = v.voice_id;
+      option.textContent = v.name;
+      select.appendChild(option);
+    });
+  } catch (err) {
+    console.error('Failed to load voices', err);
+  }
+}
+
+async function speak() {
+  const text = document.getElementById('text').value;
+  const voice = document.getElementById('voice').value;
+  const model = document.getElementById('model').value;
+  const res = await fetch('/tts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, voiceId: voice, modelId: model })
+  });
+  const blob = await res.blob();
+  const audio = document.getElementById('audio');
+  audio.src = URL.createObjectURL(blob);
+  audio.play();
+}
+
+document.getElementById('speak').addEventListener('click', speak);
+
+fetchVoices();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const fetch = require('node-fetch');
+require('dotenv').config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const API_KEY = process.env.ELEVENLABS_API_KEY;
+
+app.use(express.json());
+app.use(express.static('public'));
+
+app.get('/voices', async (req, res) => {
+  try {
+    const r = await fetch('https://api.elevenlabs.io/v1/voices', {
+      headers: { 'xi-api-key': API_KEY }
+    });
+    const data = await r.json();
+    res.json({ voices: data.voices || [] });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch voices' });
+  }
+});
+
+app.post('/tts', async (req, res) => {
+  const { text, voiceId, modelId } = req.body;
+  try {
+    const r = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream`, {
+        'xi-api-key': API_KEY,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ text, model_id: modelId })
+    });
+
+    if (!r.ok) throw new Error('API error');
+    const buffer = await r.arrayBuffer();
+    res.set('Content-Type', 'audio/mpeg');
+    res.send(Buffer.from(buffer));
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to synthesize speech' });
+  }
+});
+
+app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add web UI and client script to generate speech
- add express server to call ElevenLabs API
- document how to install dependencies and run the app

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684d5cbbf594832186b14790b707aa1b